### PR TITLE
Fix typo in pinboard message

### DIFF
--- a/pinboard/locale/de/LC_MESSAGES/django.po
+++ b/pinboard/locale/de/LC_MESSAGES/django.po
@@ -73,7 +73,7 @@ msgstr "Beitrag löschen"
 
 #: pinboard/views.py:59
 msgid "Successfully posted to pinboard"
-msgstr "Erfolgreich auf die Pinnward geschrieben"
+msgstr "Erfolgreich auf die Pinnwand geschrieben"
 
 #: pinboard/views.py:94
 msgid "Post successfully deleted"


### PR DESCRIPTION
This commit fixes the typo Pinnward to Pinnwand.